### PR TITLE
Implement RFC 2996 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ items that act as generators. It follows the general semantics of the Propane cr
 interest for this crate is for interested people to fork it and come up with their own syntax for
 these.
 
-The initial syntax looks like this and needs to be surrounded by an invocation of the
-`iterator_item` macro:
+This syntax fork implements the generator syntax from [RFC 2996](https://github.com/rust-lang/rfcs/blob/master/text/2996-async-stream.md#generator-syntax).
+It looks like this and needs to be surrounded by an invocation of the `iterator_item` macro:
 
 ```rust
-fn* foo() yields i32 {
+gen fn foo() -> i32 {
     for n in 0i32..10 {
         yield n;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 /// # use iterator_item::iterator_item;
 ///
 /// iterator_item! {
-///     fn* fizz_buzz() yields String {
+///     gen fn fizz_buzz() -> String {
 ///        for x in 1..101 {
 ///           match (x % 3 == 0, x % 5 == 0) {
 ///               (true, true)  => yield String::from("FizzBuzz"),

--- a/tests/generators.rs
+++ b/tests/generators.rs
@@ -4,7 +4,7 @@ use iterator_item::iterator_item;
 iterator_item! {
     /// Basic smoke test
     #[size_hint((10, Some(10)))]
-    fn* foo() yields i32 {
+    gen fn foo() -> i32 {
         for n in 0..10 {
             yield n;
         }
@@ -27,7 +27,7 @@ iterator_item! {
         let (x, y) = iter.size_hint();
         (x + 2, y.map(|y| y + 2))
     })]
-    fn* bar(iter: impl Iterator<Item = i32>) yields i32 {
+    gen fn bar(iter: impl Iterator<Item = i32>) -> i32 {
         yield 42;
         for n in iter {
             yield n;
@@ -44,7 +44,7 @@ fn test_bar() {
 }
 
 iterator_item! {
-    fn* result() yields Result<i32, ()> {
+    gen fn result() -> Result<i32, ()> {
         fn bar() -> Result<(), ()> {
             Err(())
         }
@@ -75,7 +75,7 @@ struct Foo(Option<i32>);
 impl Foo {
     iterator_item! {
         /// You can also have "associated iterator items"
-        fn* method(&mut self) yields i32 {
+        gen fn method(&mut self) -> i32 {
             while let Some(n) = self.0.take() {
                 yield n;
             }

--- a/tests/merge_overlapping_intervals.rs
+++ b/tests/merge_overlapping_intervals.rs
@@ -59,7 +59,7 @@ impl Interval {
 
 iterator_item! {
     /// Precondition: `input` must be sorted
-    fn* merge_overlapping_intervals(mut input: impl Iterator<Item = Interval>) yields Interval {
+    gen fn merge_overlapping_intervals(mut input: impl Iterator<Item = Interval>) -> Interval {
         let Some(mut prev) = input.next() else {
             return;
         };
@@ -124,7 +124,7 @@ fn handmade_merge_overlapping_intervals(
 
 iterator_item! {
     /// Precondition: each `Iterator` in `inputs` must be sorted
-    fn* sorted_merge_k_intervals(mut inputs: Vec<impl Iterator<Item = Interval>>) yields Interval {
+    gen fn sorted_merge_k_intervals(mut inputs: Vec<impl Iterator<Item = Interval>>) -> Interval {
         if inputs.len() == 0 {
             return;
         }
@@ -165,7 +165,7 @@ iterator_item! {
 //
 // This could be easily detected and implemented as an auto-applicable `rustc` suggestion.
 iterator_item! {
-    fn* merge_k_overlapping_intervals(inputs: Vec<impl Iterator<Item = Interval>>) yields Interval {
+    gen fn merge_k_overlapping_intervals(inputs: Vec<impl Iterator<Item = Interval>>) -> Interval {
         for i in merge_overlapping_intervals(sorted_merge_k_intervals(inputs)) {
             yield i;
         }
@@ -284,7 +284,7 @@ fn test_merge_k_overlapping_intervals() {
 
 iterator_item! {
     /// Precondition: `input` must be sorted
-    async fn* async_merge_overlapping_intervals(input: impl Stream<Item = Interval>) yields Interval {
+    async gen fn async_merge_overlapping_intervals(input: impl Stream<Item = Interval>) -> Interval {
         let mut input = Box::pin(input);
         let mut prev = if let Some(prev) = input.next().await {
             // FIXME: why din't `let else` work here?
@@ -307,7 +307,7 @@ iterator_item! {
 
 iterator_item! {
     /// Precondition: each `Iterator` in `inputs` must be sorted
-    async fn* async_sorted_merge_k_intervals(inputs: Vec<impl Stream<Item = Interval>>) yields Interval {
+    async gen fn async_sorted_merge_k_intervals(inputs: Vec<impl Stream<Item = Interval>>) -> Interval {
         if inputs.len() == 0 {
             return;
         }
@@ -348,7 +348,7 @@ iterator_item! {
 
 // We don't need as it exists but I think it's neat that we can write it this easily.
 iterator_item! {
-    async fn* into_stream(input: impl Iterator<Item = Interval>) yields Interval {
+    async gen fn into_stream(input: impl Iterator<Item = Interval>) -> Interval {
         for i in input {
             yield i;
         }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 iterator_item::iterator_item! {
-    async fn* foo<F: Future<Output = i32>>(fut: F) yields i32 {
+    async gen fn foo<F: Future<Output = i32>>(fut: F) -> i32 {
         yield 0; // `yield 0;` gets desugared to `yield Poll::Ready(0);`
         yield fut.await; // `fut.await` gets desugared to a `poll(fut, cxt)` call
         yield 2;
@@ -13,7 +13,7 @@ iterator_item::iterator_item! {
 }
 
 iterator_item::iterator_item! {
-    async fn* stream<T, F: Future<Output = T>>(futures: Vec<F>) yields T {
+    async gen fn stream<T, F: Future<Output = T>>(futures: Vec<F>) -> T {
         for future in futures {
             yield future.await;
         }
@@ -47,7 +47,7 @@ async fn test_stream() {
 }
 
 iterator_item::iterator_item! {
-    async fn* result() yields Result<i32, ()> {
+    async gen fn result() -> Result<i32, ()> {
         fn bar() -> Result<(), ()> {
             Err(())
         }


### PR DESCRIPTION
Opening a PR to help test things out, as another example syntax.

This time it's the syntax from [RFC 2996](https://github.com/rust-lang/rfcs/blob/master/text/2996-async-stream.md#generator-syntax) which looks like this:

```rust
gen fn foo() -> i32 {
    for n in 0i32..10 {
        yield n;
    }
}
```