### PR TITLE
A mix between your initial syntax and RFC 2996

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ these.
 
 [propane]: https://github.com/withoutboats/propane
 
-The initial syntax looks like this and needs to be surrounded by an invocation of the
+This syntax fork has the `fn*` header from javascript and the initial syntax example, but with the usual rust return type syntax which is also like RFC 2996. It looks like this and needs to be surrounded by an invocation of the
 `iterator_item` macro:
 
 ```rust
-fn* foo() yields i32 {
+fn* foo() -> i32 {
     for n in 0i32..10 {
         yield n;
     }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ fn* foo() -> i32 {
 }
 ```
 
+Additionally, it tries to implement something like `yield from some_iterator;` which would yield all
+items in the iterator. Since it's a bit involved to parse invalid syntax, this syntax test uses
+`yield #[from] some_iterator;` for now, to model that in spirit. (And for the same reason, only in
+sync functions: async generators don't support it at this point).
+
+It looks like this:
+
+```rust
+iterator_item! {
+    fn* yield_from_iterator<T>(it: impl Iterator<Item = T>) -> T {
+        yield #[from] it;
+    }
+}
+
+#[test]
+fn test_yield_from_iterator() {
+    let bar = yield_from_iterator(vec![1, 2, 3].into_iter());
+    assert_eq!(&[1, 2, 3][..], &bar.collect::<Vec<_>>()[..]);
+}
+```
+
 Because it is a macro, it does not work as well as a native language feature would, and has worse
 error messages, but some effort has been made to make them usable.
 

--- a/iterator_item_macros/Cargo.toml
+++ b/iterator_item_macros/Cargo.toml
@@ -9,7 +9,7 @@ description = "proc macros for the iterator_item crate"
 
 [dependencies]
 quote = "1"
-syn = { version = "1", features = ["full", "visit-mut", "parsing", "fold"] }
+syn = { version = "1", features = ["full", "visit", "visit-mut", "parsing", "fold", "extra-traits"] }
 proc-macro2 = "1"
 
 [lib]

--- a/iterator_item_macros/src/lib.rs
+++ b/iterator_item_macros/src/lib.rs
@@ -29,7 +29,7 @@ impl Parse for IteratorItemParse {
     /// Hi! If you are looking to hack on this crate to come up with your own syntax, **look here**!
     fn parse(input: ParseStream) -> Result<Self> {
         // This will parse the following:
-        // `#[attr(..)] #[attr2] pub async fn* foo(<args>) yields Ty { ... }`
+        // `#[attr(..)] #[attr2] pub async fn* foo(<args>) -> Ty { ... }`
         let attributes: Vec<Attribute> = input.call(Attribute::parse_outer)?;
         let visibility: Visibility = input.parse()?;
         let r#async: Option<Token![async]> = input.parse()?;
@@ -40,17 +40,10 @@ impl Parse for IteratorItemParse {
         let fn_args;
         parenthesized!(fn_args in input);
         let args = parse_fn_args(&fn_args)?;
-        let yields: Option<Ident> = input.parse()?;
-        let yields: Option<Type> = if let Some(yields) = yields {
-            if yields != "yields" {
-                yields
-                    .span()
-                    .unwrap()
-                    .error("expected contextual keyword `yields` or the start of an iterator body")
-                    .emit();
-                // FIXME: potentially deal better with this and try to recover the parse in a way
-                // that doesn't spam an user that forgot to write yields or tried to write `->`.
-            }
+        // Parse optional right arrow token `->`, marking the beginning of the return type
+        let lookahead = input.lookahead1();
+        let yields: Option<Type> = if lookahead.peek(Token![->]) {
+            input.parse::<Token![->]>()?;
             Some(input.parse()?)
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 /// # use iterator_item::iterator_item;
 ///
 /// iterator_item! {
-///     fn* fizz_buzz() yields String {
+///     fn* fizz_buzz() -> String {
 ///        for x in 1..101 {
 ///           match (x % 3 == 0, x % 5 == 0) {
 ///               (true, true)  => yield String::from("FizzBuzz"),

--- a/tests/generators.rs
+++ b/tests/generators.rs
@@ -4,7 +4,7 @@ use iterator_item::iterator_item;
 iterator_item! {
     /// Basic smoke test
     #[size_hint((10, Some(10)))]
-    fn* foo() yields i32 {
+    fn* foo() -> i32 {
         for n in 0..10 {
             yield n;
         }
@@ -27,7 +27,7 @@ iterator_item! {
         let (x, y) = iter.size_hint();
         (x + 2, y.map(|y| y + 2))
     })]
-    fn* bar(iter: impl Iterator<Item = i32>) yields i32 {
+    fn* bar(iter: impl Iterator<Item = i32>) -> i32 {
         yield 42;
         for n in iter {
             yield n;
@@ -44,7 +44,7 @@ fn test_bar() {
 }
 
 iterator_item! {
-    fn* result() yields Result<i32, ()> {
+    fn* result() -> Result<i32, ()> {
         fn bar() -> Result<(), ()> {
             Err(())
         }
@@ -75,7 +75,7 @@ struct Foo(Option<i32>);
 impl Foo {
     iterator_item! {
         /// You can also have "associated iterator items"
-        fn* method(&mut self) yields i32 {
+        fn* method(&mut self) -> i32 {
             while let Some(n) = self.0.take() {
                 yield n;
             }

--- a/tests/generators.rs
+++ b/tests/generators.rs
@@ -2,6 +2,18 @@
 use iterator_item::iterator_item;
 
 iterator_item! {
+    fn* yield_from_iterator<T>(it: impl Iterator<Item = T>) -> T {
+        yield #[from] it;
+    }
+}
+
+#[test]
+fn test_yield_from_iterator() {
+    let bar = yield_from_iterator(vec![1, 2, 3].into_iter());
+    assert_eq!(&[1, 2, 3][..], &bar.collect::<Vec<_>>()[..]);
+}
+
+iterator_item! {
     /// Basic smoke test
     #[size_hint((10, Some(10)))]
     fn* foo() -> i32 {
@@ -29,9 +41,7 @@ iterator_item! {
     })]
     fn* bar(iter: impl Iterator<Item = i32>) -> i32 {
         yield 42;
-        for n in iter {
-            yield n;
-        }
+        yield #[from] iter;
         yield 42;
     }
 }

--- a/tests/merge_overlapping_intervals.rs
+++ b/tests/merge_overlapping_intervals.rs
@@ -59,7 +59,7 @@ impl Interval {
 
 iterator_item! {
     /// Precondition: `input` must be sorted
-    fn* merge_overlapping_intervals(mut input: impl Iterator<Item = Interval>) yields Interval {
+    fn* merge_overlapping_intervals(mut input: impl Iterator<Item = Interval>) -> Interval {
         let Some(mut prev) = input.next() else {
             return;
         };
@@ -124,7 +124,7 @@ fn handmade_merge_overlapping_intervals(
 
 iterator_item! {
     /// Precondition: each `Iterator` in `inputs` must be sorted
-    fn* sorted_merge_k_intervals(mut inputs: Vec<impl Iterator<Item = Interval>>) yields Interval {
+    fn* sorted_merge_k_intervals(mut inputs: Vec<impl Iterator<Item = Interval>>) -> Interval {
         if inputs.len() == 0 {
             return;
         }
@@ -165,7 +165,7 @@ iterator_item! {
 //
 // This could be easily detected and implemented as an auto-applicable `rustc` suggestion.
 iterator_item! {
-    fn* merge_k_overlapping_intervals(inputs: Vec<impl Iterator<Item = Interval>>) yields Interval {
+    fn* merge_k_overlapping_intervals(inputs: Vec<impl Iterator<Item = Interval>>) -> Interval {
         for i in merge_overlapping_intervals(sorted_merge_k_intervals(inputs)) {
             yield i;
         }
@@ -284,7 +284,7 @@ fn test_merge_k_overlapping_intervals() {
 
 iterator_item! {
     /// Precondition: `input` must be sorted
-    async fn* async_merge_overlapping_intervals(input: impl Stream<Item = Interval>) yields Interval {
+    async fn* async_merge_overlapping_intervals(input: impl Stream<Item = Interval>) -> Interval {
         let mut input = Box::pin(input);
         let mut prev = if let Some(prev) = input.next().await {
             // FIXME: why din't `let else` work here?
@@ -307,7 +307,7 @@ iterator_item! {
 
 iterator_item! {
     /// Precondition: each `Iterator` in `inputs` must be sorted
-    async fn* async_sorted_merge_k_intervals(inputs: Vec<impl Stream<Item = Interval>>) yields Interval {
+    async fn* async_sorted_merge_k_intervals(inputs: Vec<impl Stream<Item = Interval>>) -> Interval {
         if inputs.len() == 0 {
             return;
         }
@@ -348,7 +348,7 @@ iterator_item! {
 
 // We don't need as it exists but I think it's neat that we can write it this easily.
 iterator_item! {
-    async fn* into_stream(input: impl Iterator<Item = Interval>) yields Interval {
+    async fn* into_stream(input: impl Iterator<Item = Interval>) -> Interval {
         for i in input {
             yield i;
         }

--- a/tests/merge_overlapping_intervals.rs
+++ b/tests/merge_overlapping_intervals.rs
@@ -166,9 +166,7 @@ iterator_item! {
 // This could be easily detected and implemented as an auto-applicable `rustc` suggestion.
 iterator_item! {
     fn* merge_k_overlapping_intervals(inputs: Vec<impl Iterator<Item = Interval>>) -> Interval {
-        for i in merge_overlapping_intervals(sorted_merge_k_intervals(inputs)) {
-            yield i;
-        }
+        yield #[from] merge_overlapping_intervals(sorted_merge_k_intervals(inputs));
     }
 }
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 iterator_item::iterator_item! {
-    async fn* foo<F: Future<Output = i32>>(fut: F) yields i32 {
+    async fn* foo<F: Future<Output = i32>>(fut: F) -> i32 {
         yield 0; // `yield 0;` gets desugared to `yield Poll::Ready(0);`
         yield fut.await; // `fut.await` gets desugared to a `poll(fut, cxt)` call
         yield 2;
@@ -13,7 +13,7 @@ iterator_item::iterator_item! {
 }
 
 iterator_item::iterator_item! {
-    async fn* stream<T, F: Future<Output = T>>(futures: Vec<F>) yields T {
+    async fn* stream<T, F: Future<Output = T>>(futures: Vec<F>) -> T {
         for future in futures {
             yield future.await;
         }
@@ -47,7 +47,7 @@ async fn test_stream() {
 }
 
 iterator_item::iterator_item! {
-    async fn* result() yields Result<i32, ()> {
+    async fn* result() -> Result<i32, ()> {
         fn bar() -> Result<(), ()> {
             Err(())
         }


### PR DESCRIPTION
Here's another quick test :)

Your & javascript's `fn*` + RFC 2996 (and regular rust) return types syntax.

```rust
fn* foo() -> i32 {
    for n in 0i32..10 {
        yield n;
    }
}
```

And for fun, something more involved (but not as involved as parsing invalid syntax as if it were valid): a simile `yield from some_iterator;` — made easier to parse with `yield #[from] some_iterator;`.

Making the first example expressible as:

```rust
fn* foo() -> i32 {
    yield #[from] 0i32..10;
}
```

(and only for sync code, not async generators)