### PR TITLE
Add generator blocks

### DIFF
--- a/iterator_item_macros/src/expand.rs
+++ b/iterator_item_macros/src/expand.rs
@@ -5,16 +5,96 @@ use syn::{
     spanned::Spanned,
     token::Brace,
     visit_mut::VisitMut,
-    Block, Expr, Item, Result, Stmt, Token,
+    Attribute, Block, Expr, Item, Macro, Result, Stmt,
 };
 
 pub struct GenMacro {
     body: Block,
+    is_async: bool,
+    is_try_yield: bool,
+    attributes: Vec<Attribute>,
 }
 
 impl GenMacro {
     fn build(self) -> Expr {
-        parse_quote! { todo!() }
+        let GenMacro {
+            mut body,
+            is_async,
+            is_try_yield,
+            attributes,
+        } = self;
+
+        let mut visitor = BodyVisitor::new(is_async, is_try_yield);
+        visitor.visit_block_mut(&mut body);
+
+        let expansion = if is_async {
+            quote!(::iterator_item::__internal::AsyncIteratorItem { gen, size_hint })
+        } else {
+            quote!(::iterator_item::__internal::IteratorItem { gen, size_hint })
+        };
+        let head = if is_async {
+            quote!(static move |mut __stream_ctx|)
+        } else {
+            quote!(move ||)
+        };
+
+        let mut size_hint = quote!((0, None));
+        for attr in attributes {
+            // An annotation of the type `#[size_hint((0, None))] fn* foo() { ... }` lets the end
+            // user provide code to override the default return of `Iterator::size_hint`.
+            // FIXME: verify if an alternative name should be considered.
+            // Once we do this is in the compiler, we can observe the materialized types of all the
+            // arguments, *and* thier uses, so that for simpler cases where iterators are being
+            // consumed once and without nesting, we can come up with an accurate `size_hint` (or
+            // at least as accurate as the `size_hint()` call is for the inputs).
+            // FIXME: we can do some of the above by modifying `Visitor` to keep track of renames
+            // and reassigns of the input bindings and of them being iterated on in for loops, but
+            // this will be tricky to get right.
+            if attr.path.get_ident().map(|a| a.to_string()).as_deref() == Some("size_hint") {
+                size_hint = attr.tokens.clone();
+            }
+        }
+
+        let tail = quote! {
+            #[allow(unreachable_code)]
+            {
+                return;
+                yield panic!();
+            }
+        };
+
+        parse_quote! {
+                #[allow(unused_parens, unused_braces)]
+                {
+                    let size_hint = #size_hint;
+                    let gen = #head {
+                        #body
+                        #tail
+                    };
+                    #expansion
+            }
+        }
+    }
+
+    fn convert_macro(mac: &Macro, attributes: &[Attribute]) -> Option<Expr> {
+        let is_gen = mac.path.is_ident("gen");
+        let is_async_gen = mac.path.is_ident("async_gen");
+        if is_gen || is_async_gen {
+            let gen = mac.parse_body::<GenMacro>();
+            Some(match gen {
+                Ok(mut gen) => {
+                    gen.is_async = is_async_gen;
+                    gen.attributes.extend_from_slice(attributes);
+                    gen.build()
+                }
+                Err(e) => {
+                    let e = e.into_compile_error();
+                    parse_quote! { { #e } }
+                }
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -25,6 +105,9 @@ impl Parse for GenMacro {
                 brace_token: Brace { span: input.span() },
                 stmts: Block::parse_within(input)?,
             },
+            is_async: false,
+            is_try_yield: false,
+            attributes: Vec::new(),
         })
     }
 }
@@ -34,15 +117,8 @@ pub struct GenMacroExpander;
 impl VisitMut for GenMacroExpander {
     fn visit_stmt_mut(&mut self, i: &mut Stmt) {
         if let Stmt::Item(Item::Macro(m)) = i {
-            if m.mac.path.is_ident("gen") {
-                let gen = m.mac.parse_body::<GenMacro>();
-                *i = match gen {
-                    Ok(gen) => Stmt::Expr(gen.build()),
-                    Err(e) => {
-                        let e = e.into_compile_error();
-                        parse_quote! { { #e } }
-                    }
-                };
+            if let Some(e) = GenMacro::convert_macro(&m.mac, &m.attrs) {
+                *i = Stmt::Expr(e);
             }
         } else {
             syn::visit_mut::visit_stmt_mut(self, i);
@@ -50,17 +126,9 @@ impl VisitMut for GenMacroExpander {
     }
 
     fn visit_expr_mut(&mut self, i: &mut Expr) {
-        eprintln!("EXPR: {}", quote! { #i });
         if let Expr::Macro(m) = i {
-            if m.mac.path.is_ident("gen") {
-                let gen = m.mac.parse_body::<GenMacro>();
-                *i = match gen {
-                    Ok(gen) => gen.build(),
-                    Err(e) => {
-                        let e = e.into_compile_error();
-                        parse_quote! { { #e } }
-                    }
-                };
+            if let Some(e) = GenMacro::convert_macro(&m.mac, &m.attrs) {
+                *i = e;
             }
         } else {
             syn::visit_mut::visit_expr_mut(self, i);

--- a/iterator_item_macros/src/expand.rs
+++ b/iterator_item_macros/src/expand.rs
@@ -9,14 +9,14 @@ use syn::{
 };
 
 pub struct GenMacro {
-    body: Block,
-    is_async: bool,
-    is_try_yield: bool,
-    attributes: Vec<Attribute>,
+    pub body: Block,
+    pub is_async: bool,
+    pub is_try_yield: bool,
+    pub attributes: Vec<Attribute>,
 }
 
 impl GenMacro {
-    fn build(self) -> Expr {
+    pub fn build(self) -> Expr {
         let GenMacro {
             mut body,
             is_async,
@@ -50,11 +50,14 @@ impl GenMacro {
             // FIXME: we can do some of the above by modifying `Visitor` to keep track of renames
             // and reassigns of the input bindings and of them being iterated on in for loops, but
             // this will be tricky to get right.
-            if attr.path.get_ident().map(|a| a.to_string()).as_deref() == Some("size_hint") {
+            if attr.path.is_ident("size_hint") {
                 size_hint = attr.tokens.clone();
             }
         }
 
+        // The `yield panic!()` in the desugaring is to allow an empty body in the input to still
+        // expand to a generator. `rustc` relies on the presence of a `yield` statement in a
+        // closure body to turn it into a generator.
         let tail = quote! {
             #[allow(unreachable_code)]
             {

--- a/iterator_item_macros/src/expand.rs
+++ b/iterator_item_macros/src/expand.rs
@@ -1,0 +1,146 @@
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_quote,
+    spanned::Spanned,
+    token::Brace,
+    visit_mut::VisitMut,
+    Block, Expr, Item, Result, Stmt, Token,
+};
+
+pub struct GenMacro {
+    body: Block,
+}
+
+impl GenMacro {
+    fn build(self) -> Expr {
+        parse_quote! { todo!() }
+    }
+}
+
+impl Parse for GenMacro {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(GenMacro {
+            body: Block {
+                brace_token: Brace { span: input.span() },
+                stmts: Block::parse_within(input)?,
+            },
+        })
+    }
+}
+
+pub struct GenMacroExpander;
+
+impl VisitMut for GenMacroExpander {
+    fn visit_stmt_mut(&mut self, i: &mut Stmt) {
+        if let Stmt::Item(Item::Macro(m)) = i {
+            if m.mac.path.is_ident("gen") {
+                let gen = m.mac.parse_body::<GenMacro>();
+                *i = match gen {
+                    Ok(gen) => Stmt::Expr(gen.build()),
+                    Err(e) => {
+                        let e = e.into_compile_error();
+                        parse_quote! { { #e } }
+                    }
+                };
+            }
+        } else {
+            syn::visit_mut::visit_stmt_mut(self, i);
+        }
+    }
+
+    fn visit_expr_mut(&mut self, i: &mut Expr) {
+        eprintln!("EXPR: {}", quote! { #i });
+        if let Expr::Macro(m) = i {
+            if m.mac.path.is_ident("gen") {
+                let gen = m.mac.parse_body::<GenMacro>();
+                *i = match gen {
+                    Ok(gen) => gen.build(),
+                    Err(e) => {
+                        let e = e.into_compile_error();
+                        parse_quote! { { #e } }
+                    }
+                };
+            }
+        } else {
+            syn::visit_mut::visit_expr_mut(self, i);
+        }
+    }
+}
+
+/// This `Visitor` allows us to modify the body (block) of the parsed item to make changes to it
+/// before passing it back to `rustc`. This allows us to construct our own desugaring for `await`
+/// and `yield`.
+pub struct BodyVisitor {
+    is_async: bool,
+    is_try_yield: bool,
+}
+
+impl BodyVisitor {
+    pub fn new(is_async: bool, is_try_yield: bool) -> Self {
+        BodyVisitor {
+            is_async,
+            is_try_yield,
+        }
+    }
+}
+
+impl VisitMut for BodyVisitor {
+    /// Desugar the iterator item's body into an underlying unstable `Generator`.
+    ///
+    /// This takes care of turning `async` iterators into a sync `Generator` body that is
+    /// equivalent to the `rustc` desugared `async` code for `async`/`await`.
+    fn visit_expr_mut(&mut self, i: &mut syn::Expr) {
+        // We traverse all the child nodes first.
+        syn::visit_mut::visit_expr_mut(self, i);
+        match i {
+            // FIXME: consider implementing `for await i in foo {}` syntax here by handling
+            // `syn::Expr::ForLoop`.
+            // FIXME: attempt to calculate `size_hint` proactively in loops by calling `size_hint`
+            // in the expression being iterated *before* building the generator. This can only work
+            // in very specific circumstances, so we need to be very clear that we are in one of
+            // the valid cases. If we do this, we need to also increment a counter for every
+            // `yield` statement outside of loops.
+            syn::Expr::Return(syn::ExprReturn { expr, .. }) => {
+                // To avoid further type errors down the line, explicitly handle this case and
+                // remove it from the resulting item body.
+                if let Some(expr) = expr {
+                    expr.span()
+                        .unwrap()
+                        .error("iterator items can't return a non-`()` value")
+                        .help("returning in an iterator is only meant for stopping the iterator")
+                        .emit();
+                }
+                *expr = None;
+            }
+            syn::Expr::Yield(syn::ExprYield {
+                expr: Some(expr), ..
+            }) if self.is_async => {
+                // Turn `yield #expr` in an `async` iterator item into `yield Poll::Ready(#expr)`
+                *i = parse_quote!(iterator_item::async_gen_yield!(#expr));
+            }
+            syn::Expr::Yield(syn::ExprYield { expr: None, .. }) if self.is_async => {
+                // Turn `yield;` in an `async` iterator item into `yield Poll::Ready(())`
+                *i = parse_quote!(iterator_item::async_gen_yield!(()));
+            }
+            syn::Expr::Await(syn::ExprAwait { base: expr, .. }) if self.is_async => {
+                // Turn `#expr.await` in an `async` iterator item into a `poll(#expr, cxt)` call
+                // (with more details, look at the macro for more)
+                *i = parse_quote!(iterator_item::async_gen_await!(#expr, __stream_ctx));
+            }
+            syn::Expr::Try(syn::ExprTry { expr, .. }) => {
+                *i = match (self.is_async, self.is_try_yield) {
+                    // Turn `#expr?` into one last `yield #expr`
+                    (true, true) => parse_quote!(iterator_item::async_gen_try!(#expr)),
+                    (false, true) => parse_quote!(iterator_item::gen_try!(#expr)),
+                    // Turn `#expr?` into an early return. This would operate better in `rustc`
+                    // with trait selection because then we can check whether the yielded value is
+                    // try. This might not be what we do, instead guide people towards `let else`.
+                    (true, false) => parse_quote!(iterator_item::async_gen_try_bare!(#expr)),
+                    (false, false) => parse_quote!(iterator_item::gen_try_bare!(#expr)),
+                };
+            }
+            _ => {}
+        }
+    }
+}

--- a/iterator_item_macros/src/lib.rs
+++ b/iterator_item_macros/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(proc_macro_diagnostic)]
 
+use crate::expand::GenMacro;
+
 use self::macrofy::macrofy;
 use expand::{BodyVisitor, GenMacroExpander};
 use proc_macro::TokenStream;
@@ -219,39 +221,7 @@ impl IteratorItemParse {
                 };
                 let mut visitor = BodyVisitor::new(is_async, is_try_yield);
                 visitor.visit_block_mut(&mut body);
-                let mut size_hint = quote!((0, None));
-                attributes.retain(|attr| {
-                    // An annotation of the type `#[size_hint((0, None))] fn* foo() { ... }` lets the end
-                    // user provide code to override the default return of `Iterator::size_hint`.
-                    // FIXME: verify if an alternative name should be considered.
-                    // Once we do this is in the compiler, we can observe the materialized types of all the
-                    // arguments, *and* thier uses, so that for simpler cases where iterators are being
-                    // consumed once and without nesting, we can come up with an accurate `size_hint` (or
-                    // at least as accurate as the `size_hint()` call is for the inputs).
-                    // FIXME: we can do some of the above by modifying `Visitor` to keep track of renames
-                    // and reassigns of the input bindings and of them being iterated on in for loops, but
-                    // this will be tricky to get right.
-                    if attr.path.get_ident().map(|a| a.to_string()).as_deref() == Some("size_hint")
-                    {
-                        size_hint = attr.tokens.clone();
-                        // We are removing the attribute from the desugaring because we are parsing it
-                        // directly.
-                        false
-                    } else {
-                        true
-                    }
-                });
 
-                // The `yield panic!()` in the desugaring is to allow an empty body in the input to still
-                // expand to a generator. `rustc` relies on the presence of a `yield` statement in a
-                // closure body to turn it into a generator.
-                let tail = quote! {
-                    #[allow(unreachable_code)]
-                    {
-                        return;
-                        yield panic!();
-                    }
-                };
                 let return_type = if is_async {
                     // Whey don't we use `std`'s `Stream` here?
                     // `Stream` is currently on the process of being reworked into `AsyncIterator`[1],
@@ -263,26 +233,20 @@ impl IteratorItemParse {
                 } else {
                     quote!(impl ::core::iter::Iterator<Item = #yields> #(+ #lifetimes)*)
                 };
-                let expansion = if is_async {
-                    quote!(::iterator_item::__internal::AsyncIteratorItem { gen, size_hint })
-                } else {
-                    quote!(::iterator_item::__internal::IteratorItem { gen, size_hint })
-                };
-                let head = if is_async {
-                    quote!(static move |mut __stream_ctx|)
-                } else {
-                    quote!(move ||)
-                };
                 let args: Vec<_> = args.into_iter().collect();
+
+                let expansion = GenMacro {
+                    body,
+                    is_async,
+                    is_try_yield,
+                    attributes: attributes.clone(),
+                }
+                .build();
+                attributes.retain(|attr| !attr.path.is_ident("size_hint"));
+
                 // Consider modifying this so that `gen` is `let gen = Box::pin(gen);`
                 let expanded = quote! {
                     #(#attributes)* #visibility fn #name #generics(#(#args),*) -> #return_type {
-                        #[allow(unused_parens)]
-                        let size_hint = #size_hint;
-                        let gen = #head {
-                            #body
-                            #tail
-                        };
                         #expansion
                     }
                 };

--- a/iterator_item_macros/src/lib.rs
+++ b/iterator_item_macros/src/lib.rs
@@ -1,28 +1,37 @@
 #![feature(proc_macro_diagnostic)]
 
+use self::macrofy::macrofy;
+use expand::{BodyVisitor, GenMacroExpander};
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 use syn::*;
 mod elision;
+mod expand;
+mod macrofy;
 
 /// AST of an iterator item. Similar to an `Item::Fn`
 ///
 /// We *could* use an `Fn` directly here, and get parsing from it, but given the objective of this
 /// crate is to explore the syntactic space, doing all of the parsing ourselves seems like a better
 /// approach.
-struct IteratorItemParse {
-    attributes: Vec<Attribute>,
-    visibility: Visibility,
-    is_async: bool,
-    name: Ident,
-    generics: Generics,
-    args: Punctuated<FnArg, Token![,]>,
-    yields: Option<Type>,
-    body: Block,
+enum IteratorItemParse {
+    Ordinary {
+        function: ItemFn,
+    },
+    Custom {
+        attributes: Vec<Attribute>,
+        visibility: Visibility,
+        is_async: bool,
+        name: Ident,
+        generics: Generics,
+        args: Punctuated<FnArg, Token![,]>,
+        yields: Option<Type>,
+        body: Block,
+    },
 }
 
 fn check_fn_star(input: ParseStream) -> bool {
@@ -63,7 +72,7 @@ fn parse_fn_star(input: ParseStream) -> Result<IteratorItemParse> {
         None
     };
     let body: Block = input.parse()?;
-    Ok(IteratorItemParse {
+    Ok(IteratorItemParse::Custom {
         attributes,
         visibility,
         is_async: r#async.is_some(),
@@ -107,6 +116,7 @@ fn parse_gen_2996(input: ParseStream) -> Result<IteratorItemParse> {
             "expected keyword `gen` marking an iterator",
         ));
     }
+    input.parse::<Token![!]>()?;
     input.parse::<Token![fn]>()?;
     let name: Ident = input.parse()?;
     let generics: Generics = input.parse()?;
@@ -122,7 +132,7 @@ fn parse_gen_2996(input: ParseStream) -> Result<IteratorItemParse> {
         None
     };
     let body: Block = input.parse()?;
-    Ok(IteratorItemParse {
+    Ok(IteratorItemParse::Custom {
         attributes,
         visibility,
         is_async: r#async.is_some(),
@@ -134,6 +144,22 @@ fn parse_gen_2996(input: ParseStream) -> Result<IteratorItemParse> {
     })
 }
 
+fn check_gen_blocks(input: ParseStream) -> bool {
+    let lookahead = input.lookahead1();
+    if lookahead.peek(Token![#]) {
+        input.parse::<Token![#]>().unwrap();
+        true
+    } else {
+        false
+    }
+}
+
+fn parse_gen_blocks(input: ParseStream) -> Result<IteratorItemParse> {
+    Ok(IteratorItemParse::Ordinary {
+        function: input.parse()?,
+    })
+}
+
 impl Parse for IteratorItemParse {
     /// Hi! If you are looking to hack on this crate to come up with your own syntax, **look here**!
     fn parse(input: ParseStream) -> Result<Self> {
@@ -141,10 +167,12 @@ impl Parse for IteratorItemParse {
             parse_fn_star(input)
         } else if check_gen_2996(input) {
             parse_gen_2996(input)
+        } else if check_gen_blocks(input) {
+            parse_gen_blocks(input)
         } else {
             Err(Error::new(
                 input.span().unwrap().into(),
-                "expected an iterator item syntax token: `*`, `!`",
+                "expected an iterator item syntax token: `*`, `!`, `#`",
             ))
         }
     }
@@ -152,195 +180,130 @@ impl Parse for IteratorItemParse {
 
 impl IteratorItemParse {
     fn build(self) -> TokenStream {
-        let IteratorItemParse {
-            mut attributes,
-            visibility,
-            is_async,
-            name,
-            mut generics,
-            args,
-            yields,
-            mut body,
-        } = self;
-        let yields = match yields {
-            Some(ty) => ty,
-            None => Type::Tuple(TypeTuple {
-                paren_token: syn::token::Paren::default(),
-                elems: Punctuated::new(),
-            }),
-        };
-        let args = elision::unelide_lifetimes(&mut generics.params, args);
-        let lifetimes: Vec<syn::Lifetime> =
-            generics.lifetimes().map(|l| l.lifetime.clone()).collect();
-
-        let is_try_yield = match yields {
-            // This would be much nicer in `rustc` desugaring because we'd have access to name resolution.
-            Type::Path(TypePath {
-                qself: None,
-                ref path,
-            }) => {
-                let is_try = path
-                    .segments
-                    .first()
-                    .map_or(false, |s| s.ident == "Result" || s.ident == "Option");
-                path.segments.len() == 1 && is_try
-            }
-            _ => false,
-        };
-        let mut visitor = Visitor::new(is_async, is_try_yield);
-        visitor.visit_block_mut(&mut body);
-        let mut size_hint = quote!((0, None));
-        attributes.retain(|attr| {
-            // An annotation of the type `#[size_hint((0, None))] fn* foo() { ... }` lets the end
-            // user provide code to override the default return of `Iterator::size_hint`.
-            // FIXME: verify if an alternative name should be considered.
-            // Once we do this is in the compiler, we can observe the materialized types of all the
-            // arguments, *and* thier uses, so that for simpler cases where iterators are being
-            // consumed once and without nesting, we can come up with an accurate `size_hint` (or
-            // at least as accurate as the `size_hint()` call is for the inputs).
-            // FIXME: we can do some of the above by modifying `Visitor` to keep track of renames
-            // and reassigns of the input bindings and of them being iterated on in for loops, but
-            // this will be tricky to get right.
-            if attr.path.get_ident().map(|a| a.to_string()).as_deref() == Some("size_hint") {
-                size_hint = attr.tokens.clone();
-                // We are removing the attribute from the desugaring because we are parsing it
-                // directly.
-                false
-            } else {
-                true
-            }
-        });
-
-        // The `yield panic!()` in the desugaring is to allow an empty body in the input to still
-        // expand to a generator. `rustc` relies on the presence of a `yield` statement in a
-        // closure body to turn it into a generator.
-        let tail = quote! {
-            #[allow(unreachable_code)]
-            {
-                return;
-                yield panic!();
-            }
-        };
-        let return_type = if is_async {
-            // Whey don't we use `std`'s `Stream` here?
-            // `Stream` is currently on the process of being reworked into `AsyncIterator`[1],
-            // leveraging associated `async fn` support that isn't yet in nightly. For now, we
-            // just rely on the library that people are actually using, the futures' crate Stream.
-            // [1]: https://rust-lang.github.io/wg-async-foundations/vision/roadmap/async_iter/traits.html
-            // quote! { impl ::core::stream::Stream<Item = #yields> #(+ #lifetimes)* }
-            quote!(impl ::futures::stream::Stream<Item = #yields> #(+ #lifetimes)*)
-        } else {
-            quote!(impl ::core::iter::Iterator<Item = #yields> #(+ #lifetimes)*)
-        };
-        let expansion = if is_async {
-            quote!(::iterator_item::__internal::AsyncIteratorItem { gen, size_hint })
-        } else {
-            quote!(::iterator_item::__internal::IteratorItem { gen, size_hint })
-        };
-        let head = if is_async {
-            quote!(static move |mut __stream_ctx|)
-        } else {
-            quote!(move ||)
-        };
-        let args: Vec<_> = args.into_iter().collect();
-        // Consider modifying this so that `gen` is `let gen = Box::pin(gen);`
-        let expanded = quote! {
-            #(#attributes)* #visibility fn #name #generics(#(#args),*) -> #return_type {
-                #[allow(unused_parens)]
-                let size_hint = #size_hint;
-                let gen = #head {
-                    #body
-                    #tail
+        match self {
+            IteratorItemParse::Custom {
+                mut attributes,
+                visibility,
+                is_async,
+                name,
+                mut generics,
+                args,
+                yields,
+                mut body,
+            } => {
+                let yields = match yields {
+                    Some(ty) => ty,
+                    None => Type::Tuple(TypeTuple {
+                        paren_token: syn::token::Paren::default(),
+                        elems: Punctuated::new(),
+                    }),
                 };
-                #expansion
-            }
-        };
+                let args = elision::unelide_lifetimes(&mut generics.params, args);
+                let lifetimes: Vec<syn::Lifetime> =
+                    generics.lifetimes().map(|l| l.lifetime.clone()).collect();
 
-        TokenStream::from(expanded)
+                let is_try_yield = match yields {
+                    // This would be much nicer in `rustc` desugaring because we'd have access to name resolution.
+                    Type::Path(TypePath {
+                        qself: None,
+                        ref path,
+                    }) => {
+                        let is_try = path
+                            .segments
+                            .first()
+                            .map_or(false, |s| s.ident == "Result" || s.ident == "Option");
+                        path.segments.len() == 1 && is_try
+                    }
+                    _ => false,
+                };
+                let mut visitor = BodyVisitor::new(is_async, is_try_yield);
+                visitor.visit_block_mut(&mut body);
+                let mut size_hint = quote!((0, None));
+                attributes.retain(|attr| {
+                    // An annotation of the type `#[size_hint((0, None))] fn* foo() { ... }` lets the end
+                    // user provide code to override the default return of `Iterator::size_hint`.
+                    // FIXME: verify if an alternative name should be considered.
+                    // Once we do this is in the compiler, we can observe the materialized types of all the
+                    // arguments, *and* thier uses, so that for simpler cases where iterators are being
+                    // consumed once and without nesting, we can come up with an accurate `size_hint` (or
+                    // at least as accurate as the `size_hint()` call is for the inputs).
+                    // FIXME: we can do some of the above by modifying `Visitor` to keep track of renames
+                    // and reassigns of the input bindings and of them being iterated on in for loops, but
+                    // this will be tricky to get right.
+                    if attr.path.get_ident().map(|a| a.to_string()).as_deref() == Some("size_hint")
+                    {
+                        size_hint = attr.tokens.clone();
+                        // We are removing the attribute from the desugaring because we are parsing it
+                        // directly.
+                        false
+                    } else {
+                        true
+                    }
+                });
+
+                // The `yield panic!()` in the desugaring is to allow an empty body in the input to still
+                // expand to a generator. `rustc` relies on the presence of a `yield` statement in a
+                // closure body to turn it into a generator.
+                let tail = quote! {
+                    #[allow(unreachable_code)]
+                    {
+                        return;
+                        yield panic!();
+                    }
+                };
+                let return_type = if is_async {
+                    // Whey don't we use `std`'s `Stream` here?
+                    // `Stream` is currently on the process of being reworked into `AsyncIterator`[1],
+                    // leveraging associated `async fn` support that isn't yet in nightly. For now, we
+                    // just rely on the library that people are actually using, the futures' crate Stream.
+                    // [1]: https://rust-lang.github.io/wg-async-foundations/vision/roadmap/async_iter/traits.html
+                    // quote! { impl ::core::stream::Stream<Item = #yields> #(+ #lifetimes)* }
+                    quote!(impl ::futures::stream::Stream<Item = #yields> #(+ #lifetimes)*)
+                } else {
+                    quote!(impl ::core::iter::Iterator<Item = #yields> #(+ #lifetimes)*)
+                };
+                let expansion = if is_async {
+                    quote!(::iterator_item::__internal::AsyncIteratorItem { gen, size_hint })
+                } else {
+                    quote!(::iterator_item::__internal::IteratorItem { gen, size_hint })
+                };
+                let head = if is_async {
+                    quote!(static move |mut __stream_ctx|)
+                } else {
+                    quote!(move ||)
+                };
+                let args: Vec<_> = args.into_iter().collect();
+                // Consider modifying this so that `gen` is `let gen = Box::pin(gen);`
+                let expanded = quote! {
+                    #(#attributes)* #visibility fn #name #generics(#(#args),*) -> #return_type {
+                        #[allow(unused_parens)]
+                        let size_hint = #size_hint;
+                        let gen = #head {
+                            #body
+                            #tail
+                        };
+                        #expansion
+                    }
+                };
+
+                TokenStream::from(expanded)
+            }
+            IteratorItemParse::Ordinary { mut function } => {
+                GenMacroExpander.visit_item_fn_mut(&mut function);
+                eprintln!("{}", quote! { #function });
+                function.to_token_stream().into()
+            }
+        }
     }
 }
 
 #[proc_macro]
 pub fn iterator_item(input: TokenStream) -> TokenStream {
+    // change gen => gen! so we get a second shot at parsing wherever it appears in an expression
+    let input = macrofy(input.into());
+    // actually parse the macro input
     let item: IteratorItemParse = parse_macro_input!(input as IteratorItemParse);
     item.build()
-}
-
-/// This `Visitor` allows us to modify the body (block) of the parsed item to make changes to it
-/// before passing it back to `rustc`. This allows us to construct our own desugaring for `await`
-/// and `yield`.
-struct Visitor {
-    is_async: bool,
-    is_try_yield: bool,
-}
-
-impl Visitor {
-    fn new(is_async: bool, is_try_yield: bool) -> Self {
-        Visitor {
-            is_async,
-            is_try_yield,
-        }
-    }
-}
-
-impl VisitMut for Visitor {
-    /// Desugar the iterator item's body into an underlying unstable `Generator`.
-    ///
-    /// This takes care of turning `async` iterators into a sync `Generator` body that is
-    /// equivalent to the `rustc` desugared `async` code for `async`/`await`.
-    fn visit_expr_mut(&mut self, i: &mut syn::Expr) {
-        // We traverse all the child nodes first.
-        syn::visit_mut::visit_expr_mut(self, i);
-        match i {
-            // FIXME: consider implementing `for await i in foo {}` syntax here by handling
-            // `syn::Expr::ForLoop`.
-            // FIXME: attempt to calculate `size_hint` proactively in loops by calling `size_hint`
-            // in the expression being iterated *before* building the generator. This can only work
-            // in very specific circumstances, so we need to be very clear that we are in one of
-            // the valid cases. If we do this, we need to also increment a counter for every
-            // `yield` statement outside of loops.
-            syn::Expr::Return(syn::ExprReturn { expr, .. }) => {
-                // To avoid further type errors down the line, explicitly handle this case and
-                // remove it from the resulting item body.
-                if let Some(expr) = expr {
-                    expr.span()
-                        .unwrap()
-                        .error("iterator items can't return a non-`()` value")
-                        .help("returning in an iterator is only meant for stopping the iterator")
-                        .emit();
-                }
-                *expr = None;
-            }
-            syn::Expr::Yield(syn::ExprYield {
-                expr: Some(expr), ..
-            }) if self.is_async => {
-                // Turn `yield #expr` in an `async` iterator item into `yield Poll::Ready(#expr)`
-                *i = parse_quote!(iterator_item::async_gen_yield!(#expr));
-            }
-            syn::Expr::Yield(syn::ExprYield { expr: None, .. }) if self.is_async => {
-                // Turn `yield;` in an `async` iterator item into `yield Poll::Ready(())`
-                *i = parse_quote!(iterator_item::async_gen_yield!(()));
-            }
-            syn::Expr::Await(syn::ExprAwait { base: expr, .. }) if self.is_async => {
-                // Turn `#expr.await` in an `async` iterator item into a `poll(#expr, cxt)` call
-                // (with more details, look at the macro for more)
-                *i = parse_quote!(iterator_item::async_gen_await!(#expr, __stream_ctx));
-            }
-            syn::Expr::Try(syn::ExprTry { expr, .. }) => {
-                *i = match (self.is_async, self.is_try_yield) {
-                    // Turn `#expr?` into one last `yield #expr`
-                    (true, true) => parse_quote!(iterator_item::async_gen_try!(#expr)),
-                    (false, true) => parse_quote!(iterator_item::gen_try!(#expr)),
-                    // Turn `#expr?` into an early return. This would operate better in `rustc`
-                    // with trait selection because then we can check whether the yielded value is
-                    // try. This might not be what we do, instead guide people towards `let else`.
-                    (true, false) => parse_quote!(iterator_item::async_gen_try_bare!(#expr)),
-                    (false, false) => parse_quote!(iterator_item::gen_try_bare!(#expr)),
-                };
-            }
-            _ => {}
-        }
-    }
 }
 
 /// Copied from `syn` because it exists but it is private 🤷

--- a/iterator_item_macros/src/macrofy.rs
+++ b/iterator_item_macros/src/macrofy.rs
@@ -1,0 +1,36 @@
+use proc_macro::{Group, Punct, Spacing, TokenStream, TokenTree};
+use std::mem::replace;
+
+struct Macrofy<I: Iterator<Item = TokenTree>> {
+    inner: I,
+    needs_bang: bool,
+}
+
+impl<I: Iterator<Item = TokenTree>> Iterator for Macrofy<I> {
+    type Item = TokenTree;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let needs_bang = replace(&mut self.needs_bang, false);
+        Some(if needs_bang {
+            TokenTree::Punct(Punct::new('!', Spacing::Alone))
+        } else {
+            match self.inner.next()? {
+                TokenTree::Ident(i) if i.to_string() == "gen" => {
+                    self.needs_bang = true;
+                    TokenTree::Ident(i)
+                }
+                TokenTree::Group(g) => {
+                    TokenTree::Group(Group::new(g.delimiter(), macrofy(g.stream())))
+                }
+                other => other,
+            }
+        })
+    }
+}
+
+pub fn macrofy(input: TokenStream) -> TokenStream {
+    TokenStream::from_iter(Macrofy {
+        inner: input.into_iter(),
+        needs_bang: false,
+    })
+}

--- a/iterator_item_macros/src/macrofy.rs
+++ b/iterator_item_macros/src/macrofy.rs
@@ -1,36 +1,74 @@
-use proc_macro::{Group, Punct, Spacing, TokenStream, TokenTree};
-use std::mem::replace;
+use proc_macro::{Group, Ident, Punct, Spacing, TokenStream, TokenTree};
+use std::{collections::VecDeque, mem::replace};
+
+enum MacrofyState {
+    Passthrough,
+    SawAsync(Ident),
+}
+
+fn bang() -> TokenTree {
+    TokenTree::Punct(Punct::new('!', Spacing::Alone))
+}
+
+impl MacrofyState {
+    fn step(&mut self, tree: TokenTree, out: &mut VecDeque<TokenTree>) {
+        use MacrofyState::*;
+
+        *self = match (replace(self, Passthrough), tree) {
+            (Passthrough, TokenTree::Group(g)) => {
+                out.push_back(TokenTree::Group(Group::new(
+                    g.delimiter(),
+                    macrofy(g.stream()),
+                )));
+                Passthrough
+            }
+            (Passthrough, TokenTree::Ident(i)) if i.to_string() == "gen" => {
+                out.push_back(TokenTree::Ident(i));
+                out.push_back(bang());
+                Passthrough
+            }
+            (SawAsync(_), TokenTree::Ident(i)) if i.to_string() == "gen" => {
+                out.push_back(TokenTree::Ident(Ident::new("async_gen", i.span())));
+                out.push_back(bang());
+                Passthrough
+            }
+            (SawAsync(a), tok) => {
+                out.push_back(TokenTree::Ident(a));
+                out.push_back(tok);
+                Passthrough
+            }
+            (Passthrough, TokenTree::Ident(i)) if i.to_string() == "async" => SawAsync(i),
+            (_, tok) => {
+                out.push_back(tok);
+                Passthrough
+            }
+        };
+    }
+}
 
 struct Macrofy<I: Iterator<Item = TokenTree>> {
     inner: I,
-    needs_bang: bool,
+    queue: VecDeque<TokenTree>,
+    state: MacrofyState,
 }
 
 impl<I: Iterator<Item = TokenTree>> Iterator for Macrofy<I> {
     type Item = TokenTree;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let needs_bang = replace(&mut self.needs_bang, false);
-        Some(if needs_bang {
-            TokenTree::Punct(Punct::new('!', Spacing::Alone))
-        } else {
-            match self.inner.next()? {
-                TokenTree::Ident(i) if i.to_string() == "gen" => {
-                    self.needs_bang = true;
-                    TokenTree::Ident(i)
-                }
-                TokenTree::Group(g) => {
-                    TokenTree::Group(Group::new(g.delimiter(), macrofy(g.stream())))
-                }
-                other => other,
+        loop {
+            if let Some(tok) = self.queue.pop_front() {
+                return Some(tok);
             }
-        })
+            self.state.step(self.inner.next()?, &mut self.queue);
+        }
     }
 }
 
 pub fn macrofy(input: TokenStream) -> TokenStream {
     TokenStream::from_iter(Macrofy {
         inner: input.into_iter(),
-        needs_bang: false,
+        queue: VecDeque::with_capacity(2),
+        state: MacrofyState::Passthrough,
     })
 }

--- a/tests/gen_blocks.rs
+++ b/tests/gen_blocks.rs
@@ -68,15 +68,14 @@ fn test_early_return() {
     assert_eq!(result.next(), Some(3));
     assert!(result.next().is_none())
 }
-
 struct Foo(Option<i32>);
 
 impl Foo {
     iterator_item! { #
-        /// You can also have "associated iterator items"
-        fn method(&mut self) -> impl Iterator<Item=i32> + '_ {
+        fn method(&mut self) -> impl Iterator<Item=i32> {
+            let num = self.0.take();
             gen {
-                while let Some(n) = self.0.take() {
+                while let Some(n) = num {
                     yield n;
                 }
             }

--- a/tests/gen_blocks.rs
+++ b/tests/gen_blocks.rs
@@ -1,0 +1,111 @@
+#![feature(generators, generator_trait, let_else, try_trait_v2)]
+use iterator_item::iterator_item;
+
+iterator_item! { #
+    /// Basic smoke test
+    fn foo() -> impl Iterator<Item=i32> {
+        gen {
+            for n in 0..10 {
+                yield n;
+            }
+        }
+    }
+}
+
+#[test]
+fn test_foo() {
+    let mut foo = foo();
+    // assert_eq!(foo.size_hint(), (10, Some(10)));
+    for n in 0..10 {
+        assert_eq!(foo.next(), Some(n));
+    }
+    assert!(foo.next().is_none());
+}
+
+iterator_item! { !
+    /// Show off the way you can write a custom `size_hint` impl.
+    #[size_hint({
+        let (x, y) = iter.size_hint();
+        (x + 2, y.map(|y| y + 2))
+    })]
+    gen fn bar(iter: impl Iterator<Item = i32>) -> i32 {
+        yield 42;
+        for n in iter {
+            yield n;
+        }
+        yield 42;
+    }
+}
+
+#[test]
+fn test_bar() {
+    let bar = bar(vec![1, 2, 3].into_iter());
+    assert_eq!(bar.size_hint(), (5, Some(5)));
+    assert_eq!(&[42, 1, 2, 3, 42][..], &bar.collect::<Vec<_>>()[..]);
+}
+
+iterator_item! { !
+    gen fn result() -> Result<i32, ()> {
+        fn bar() -> Result<(), ()> {
+            Err(())
+        }
+
+        for n in 0..5 {
+            yield Ok(n);
+        }
+
+        bar()?;
+
+        yield Ok(10); // will not be evaluated
+    }
+}
+
+#[test]
+fn test_result() {
+    let mut result = result();
+    for n in 0..5 {
+        assert_eq!(result.next(), Some(Ok(n)));
+    }
+
+    assert_eq!(result.next(), Some(Err(())));
+    assert!(result.next().is_none())
+}
+
+iterator_item! { !
+    gen fn early_return() -> i32 {
+        let mut x = Some(3);
+        let y = x.take()?;
+        yield y;
+        let y = x.take()?;
+        yield y;
+    }
+}
+
+#[test]
+fn test_early_return() {
+    let mut result = early_return();
+
+    assert_eq!(result.next(), Some(3));
+    assert!(result.next().is_none())
+}
+
+struct Foo(Option<i32>);
+
+impl Foo {
+    iterator_item! { !
+        /// You can also have "associated iterator items"
+        gen fn method(&mut self) -> i32 {
+            while let Some(n) = self.0.take() {
+                yield n;
+            }
+        }
+    }
+}
+
+#[test]
+fn test_foo_method() {
+    let mut foo = Foo(Some(0));
+    let mut iter = foo.method();
+    assert_eq!(iter.next(), Some(0));
+    assert!(iter.next().is_none());
+}


### PR DESCRIPTION
This code is to support generator blocks (as seen on zulip!):
```rust
type MyIterator = impl Iterator<Item=i32>;

let count = 20;
let my_iter: MyIterator = gen {
    for i in 0..count {
        yield i;
    }
};
```

The implementation here is a bit invasive because I wanted to work with the existing macro in case someone wants to try any sort of mixed syntax. The general idea is I convert `gen { ... }` to `gen! { ... }` everywhere before parsing, so that syn is happy parsing the code overall, and a second pass can be made by a visitor.